### PR TITLE
Hold forwarding state assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ We have built some list commands that can be used to check the "internals" of th
    sudo hpim-dm -fid
    ```
 
+ - #### Hold Forwarding State:
+
+   This setting allows during an AW replacement (for example due to RPC changes) for the previous AW to hold its forwarding state for a small amount of time. This way it is possible to prevent loss of data packets during this event, however it may introduce traffic duplication (while the new and the previous AW both forward traffic). By default this setting is enabled with a time period of 2 seconds.
+
+   ```
+   sudo hpim-dm -hfs
+   ```
 
 Files tree/protocol_globals.py and igmp/igmp_globals.py store all timer values and some configurations regarding IGMPv2 and HPIM-DM. If you want to tune the protocol, you can change the values of these files. These configurations are used by all interfaces, meaning that there is no tuning per interface.
 

--- a/hpimdm/Main.py
+++ b/hpimdm/Main.py
@@ -230,6 +230,15 @@ def change_initial_flood_setting():
     return "Flood is enabled?: " + str(protocol_globals.INITIAL_FLOOD_ENABLED)
 
 
+def hold_forwarding_state():
+    """
+    Change Hold Forwarding State Setting, used to hold the forwarding state of an interface that was AW and that became
+    AL
+    """
+    protocol_globals.AL_HOLD_FORWARDING_STATE_ENABLED ^= True
+    return "Hold Forwarding State is enabled?: " + str(protocol_globals.AL_HOLD_FORWARDING_STATE_ENABLED)
+
+
 def stop():
     """
     Stop process

--- a/hpimdm/Neighbor.py
+++ b/hpimdm/Neighbor.py
@@ -22,7 +22,7 @@ else:
 if TYPE_CHECKING:
     from hpimdm.InterfaceProtocol import InterfaceProtocol
 
-DEFAULT_HELLO_HOLD_TIME_DURING_SYNC = 25
+DEFAULT_HELLO_HOLD_TIME_DURING_SYNC = 4 * protocol_globals.SYNC_RETRANSMISSION_TIME
 DEFAULT_HELLO_HOLD_TIME_AFTER_SYNC = 120
 
 class NeighborState():
@@ -303,7 +303,7 @@ class Neighbor:
         Set Sync timer... useful when the Sync process is making progress and a Sync message from the neighbor node must be received
         """
         self.clear_sync_timer()
-        self.sync_timer = Timer(10, self.sync_timeout)
+        self.sync_timer = Timer(protocol_globals.SYNC_RETRANSMISSION_TIME, self.sync_timeout)
         self.sync_timer.start()
 
     def clear_sync_timer(self):

--- a/hpimdm/Run.py
+++ b/hpimdm/Run.py
@@ -78,6 +78,8 @@ class MyDaemon(Daemon):
                     connection.shutdown(socket.SHUT_RDWR)
                 elif 'flood_initial_data' in args and args.flood_initial_data:
                     connection.sendall(pickle.dumps(Main.change_initial_flood_setting()))
+                elif 'hold_forwarding_state' in args and args.hold_forwarding_state:
+                    connection.sendall(pickle.dumps(Main.hold_forwarding_state()))
                 elif 'add_interface_igmp' in args and args.add_interface_igmp:
                     Main.add_igmp_interface(args.add_interface_igmp[0])
                     connection.shutdown(socket.SHUT_RDWR)
@@ -136,6 +138,9 @@ def main():
                        help="List Multicast Routing table")
     group.add_argument("-fid", "--flood_initial_data", action="store_true", default=False,
                        help="Flood initial data packets")
+    group.add_argument("-hfs", "--hold_forwarding_state", action="store_true", default=False,
+                       help="Hold forwarding state during a small amount of time after AW interface becomes AL " +\
+                            "(prevent loss of data packets after AW replacement)")
     group.add_argument("-ai", "--add_interface", nargs=1, metavar='INTERFACE_NAME',
                        help="Add HPIM-DM interface")
     group.add_argument("-aiigmp", "--add_interface_igmp", nargs=1, metavar='INTERFACE_NAME',

--- a/hpimdm/tree/protocol_globals.py
+++ b/hpimdm/tree/protocol_globals.py
@@ -24,3 +24,18 @@ SYNC_FRAGMENTATION_MSG = 0
 # Number of ACKs that must be missed in order to declare a neighbor to have failed
 # Use a number HIGHER than 1!!
 ACK_FAILURE_THRESHOLD = 3
+
+
+# Time to wait for a Sync message
+# If Synchronization does not make progress, retransmit previous Sync message
+SYNC_RETRANSMISSION_TIME = 3
+
+
+# When an AW loses an assert and becomes AL, it can hold its forwarding state for a given ammount of time to prevent
+# the loss of data packes (the new AW may not be receiving multicast tree from its parent yet causing the interest
+# signaling to be propageted upwards the tree).
+# If enabled this prevents loss of data packets after the AW is replaced, but duplications may occur for a small
+#   amount of time (the AW and the AL may both forwarding packets at the same time during AL_HOLD_FORWARDING_STATE_TIME)
+# If disabled the duplication of data packets does not occur but loss of packets may occur
+AL_HOLD_FORWARDING_STATE_ENABLED = True
+AL_HOLD_FORWARDING_STATE_TIME = 2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description="HPIM-DM protocol",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
-    version="1.0.1",
+    version="1.0.2",
     url="http://github.com/pedrofran12/hpim_dm",
     author='Pedro Oliveira',
     author_email='pedro.francisco.oliveira@tecnico.ulisboa.pt',


### PR DESCRIPTION
Allow an AW that loses an Assert to hold its forwarding state for a period of time. In this way it is possible to minimize loss of data packets during the replacement of the AW. However this introduces possible duplications while the previous AW is holding its forwarding state.
It is possible for the user to configure this setting (with -hfs option).